### PR TITLE
Refactor to allow optional dependency management

### DIFF
--- a/manifests/deps.pp
+++ b/manifests/deps.pp
@@ -11,20 +11,15 @@
 # Copyright 2013 Justin Downing
 #
 class rbenv::deps {
-  include ::stdlib
-
   case $::osfamily {
     'Debian': {
       include rbenv::deps::debian
-      $group = 'adm'
     }
     'RedHat': {
       include rbenv::deps::redhat
-      $group = 'wheel'
     }
     'Suse': {
       include rbenv::deps::suse
-      $group = 'users'
     }
     default: {
       fail('The rbenv module currently only suports Debian, RedHat, and Suse.')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,14 +63,17 @@ class rbenv (
   $repo_path   = 'https://github.com/sstephenson/rbenv.git',
   $install_dir = '/usr/local/rbenv',
   $owner       = 'root',
-  $group       = $rbenv::deps::group,
+  $group       = $rbenv::params::group,
   $latest      = false,
   $env         = [],
-) inherits rbenv::deps {
+  $manage_deps = true,
+) inherits rbenv::params {
 
   validate_array($env)
 
-  include rbenv::deps
+  if $manage_deps {
+    include rbenv::deps
+  }
 
   exec { 'git-clone-rbenv':
     command     => "/usr/bin/git clone ${rbenv::repo_path} ${install_dir}",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,20 @@
+# == Class: rbenv::params
+#
+# This class manages per-osfamily rbenv settings
+#
+class rbenv::params {
+  case $::osfamily {
+    'Debian': {
+      $group = 'adm'
+    }
+    'RedHat': {
+      $group = 'wheel'
+    }
+    'Suse': {
+      $group = 'users'
+    }
+    default: {
+      fail('The rbenv module currently only suports Debian, RedHat, and Suse.')
+    }
+  }
+}


### PR DESCRIPTION
Move platform-specific parameters into params class, then add a
manage_deps parameter to control whether dependency packages are
included.

This fixes a resource conflict issue because ensure_resources is parse order
dependent. For example, if the git package is declared in a different
module but this module is evaluated first, the catalog compilation will
fail.

Also remove unnecessary stdlib include because stdlib doesn't actually
do anything. Everything in stdlib is functions.
